### PR TITLE
support current_timestamp in utc for sqlite

### DIFF
--- a/lib/sequel/extensions/activerecord_connection.rb
+++ b/lib/sequel/extensions/activerecord_connection.rb
@@ -5,9 +5,6 @@ module Sequel
     def self.extended(db)
       db.activerecord_model = ActiveRecord::Base
       db.timezone = ActiveRecord::Base.default_timezone
-      if db.adapter_scheme == :sqlite && db.respond_to?(:current_timestamp_utc)
-        db.current_timestamp_utc = ActiveRecord::Base.default_timezone
-      end
 
       begin
         require "sequel/extensions/activerecord_connection/#{db.adapter_scheme}"

--- a/lib/sequel/extensions/activerecord_connection.rb
+++ b/lib/sequel/extensions/activerecord_connection.rb
@@ -5,6 +5,9 @@ module Sequel
     def self.extended(db)
       db.activerecord_model = ActiveRecord::Base
       db.timezone = ActiveRecord::Base.default_timezone
+      if db.adapter_scheme == :sqlite && db.respond_to?(:current_timestamp_utc)
+        db.current_timestamp_utc = ActiveRecord::Base.default_timezone
+      end
 
       begin
         require "sequel/extensions/activerecord_connection/#{db.adapter_scheme}"

--- a/lib/sequel/extensions/activerecord_connection/sqlite.rb
+++ b/lib/sequel/extensions/activerecord_connection/sqlite.rb
@@ -1,6 +1,12 @@
 module Sequel
   module ActiveRecordConnection
     module Sqlite
+      def self.extended(db)
+        if db.timezone == :utc && db.respond_to?(:current_timestamp_utc)
+          db.current_timestamp_utc = true
+        end
+      end
+
       def execute_ddl(sql, opts=OPTS)
         execute(sql, opts)
       end

--- a/test/sqlite_test.rb
+++ b/test/sqlite_test.rb
@@ -104,6 +104,14 @@ describe "sqlite3 connection" do
     SQL
   end
 
+  it "adds CURRENT_* timestamp in UTC when that's ActiveRecord's timezone" do
+    @db.extension :date_arithmetic
+    @db[:records].insert(time: Time.now)
+
+    refute_empty @db[:records].where(Sequel[:time] < Sequel.date_add(Sequel::CURRENT_TIMESTAMP, minutes: 1))
+    refute_empty @db[:records].where(Sequel[:time] > Sequel.date_sub(Sequel::CURRENT_TIMESTAMP, minutes: 1))
+  end if Sequel::MAJOR >= 5 && Sequel::MINOR >= 33
+
   it "correctly handles ActiveRecord's local timezone setting" do
     ActiveRecord::Base.default_timezone = :local
     @db.timezone = :local


### PR DESCRIPTION
Closes #1 

To make `Sequel::CURRENT_TIMESTAMP` work reasonably well when in tandem with ActiveRecord, which sets UTC as default timezone.