### PR TITLE
removing usage of keyword arguments in #transaction

### DIFF
--- a/lib/sequel/extensions/activerecord_connection.rb
+++ b/lib/sequel/extensions/activerecord_connection.rb
@@ -22,10 +22,10 @@ module Sequel
     end
 
     def transaction(options = {})
-      savepoint = options.delete(:savepoint)
-      rollback = options.delete(:rollback)
+      savepoint      = options.delete(:savepoint)
+      rollback       = options.delete(:rollback)
       auto_savepoint = options.delete(:auto_savepoint)
-      server = options.delete(:server)
+      server         = options.delete(:server)
 
       fail Error, "#{options} transaction options are currently not supported" unless options.empty?
 

--- a/lib/sequel/extensions/activerecord_connection.rb
+++ b/lib/sequel/extensions/activerecord_connection.rb
@@ -21,7 +21,12 @@ module Sequel
       raise Error, "creating a Sequel connection is not allowed"
     end
 
-    def transaction(savepoint: nil, rollback: nil, auto_savepoint: nil, server: nil, **options)
+    def transaction(options = {})
+      savepoint = options.delete(:savepoint)
+      rollback = options.delete(:rollback)
+      auto_savepoint = options.delete(:auto_savepoint)
+      server = options.delete(:server)
+
       fail Error, "#{options} transaction options are currently not supported" unless options.empty?
 
       if in_transaction?


### PR DESCRIPTION
I'm getting the following warning:

```
 warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/lib/sequel/extensions/activerecord_connection.rb:24: warning: The called method `transaction' is defined here
```

when I call `db.transaction`, with no arguments. This should fix it, as this seems to be an inconsistency between what sequel expects (an hash) and what this gem expects (keyword arguments), and them not being the same, as per the ruby 2.7 warnings.