### PR TITLE
use utc in sqlite/jruby as well

### DIFF
--- a/lib/sequel/extensions/activerecord_connection/jdbc.rb
+++ b/lib/sequel/extensions/activerecord_connection/jdbc.rb
@@ -1,6 +1,12 @@
 module Sequel
   module ActiveRecordConnection
     module Jdbc
+      def self.extended(db)
+        if db.timezone == :utc && db.respond_to?(:current_timestamp_utc)
+          db.current_timestamp_utc = true
+        end
+      end
+
       def statement(conn)
         stmt = activerecord_raw_connection.connection.createStatement
         yield stmt


### PR DESCRIPTION
After you last update, I realized that I didn't test it enough with jruby, and I got burned by the UTC sqlite case again... Apologies for that. Here's the fix.