### PR TITLE
Fix: Sequel::Model#update returns nil instead of model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## HEAD
+
+* Return block result in `Sequel::Database#transaction` (@zabolotnov87, @janko)
+
+* Fix `Sequel::Model#save_changes` or `#save` with additional options not executing (@zabolotnov87, @janko)
+
 ## 0.2.5 (2020-06-04)
 
 * Use `#current_timestamp_utc` for the JDBC SQLite adapter as well (@HoneyryderChuck)

--- a/lib/sequel/extensions/activerecord_connection.rb
+++ b/lib/sequel/extensions/activerecord_connection.rb
@@ -22,32 +22,21 @@ module Sequel
     end
 
     def transaction(options = {})
-      options = keep_transaction_options(options)
-
-      savepoint      = options.delete(:savepoint)
-      rollback       = options.delete(:rollback)
-      auto_savepoint = options.delete(:auto_savepoint)
-      server         = options.delete(:server)
-
-      fail Error, "#{options} transaction options are currently not supported" unless options.empty?
-
-      if in_transaction?
-        requires_new = savepoint || Thread.current[:sequel_activerecord_auto_savepoint]
-      else
-        requires_new = true
+      %i[isolation num_retries before_retry prepare retry_on].each do |key|
+        fail Error, "#{key.inspect} transaction option is currently not supported" if options.key?(key)
       end
 
-      activerecord_model.transaction(requires_new: requires_new) do
+      activerecord_model.transaction(requires_new: !in_transaction? || options[:savepoint] || Thread.current[:sequel_activerecord_auto_savepoint]) do
         begin
-          Thread.current[:sequel_activerecord_auto_savepoint] = true if auto_savepoint
+          Thread.current[:sequel_activerecord_auto_savepoint] = true if options[:auto_savepoint]
           result = yield
-          raise ActiveRecord::Rollback if rollback == :always
+          raise ActiveRecord::Rollback if options[:rollback] == :always
           result
         rescue Sequel::Rollback => exception
-          raise if rollback == :reraise
+          raise if options[:rollback] == :reraise
           raise ActiveRecord::Rollback, exception.message, exception.backtrace
         ensure
-          Thread.current[:sequel_activerecord_auto_savepoint] = nil if auto_savepoint
+          Thread.current[:sequel_activerecord_auto_savepoint] = nil if options[:auto_savepoint]
         end
       end
     end
@@ -74,23 +63,6 @@ module Sequel
     end
 
     private
-
-    def keep_transaction_options(options)
-      options.slice(
-        :auto_savepoint,
-        :isolation,
-        :num_retries,
-        :before_retry,
-        :prepare,
-        :retry_on,
-        :rollback,
-        :server,
-        :savepoint,
-        :deferrable,
-        :read_only,
-        :synchronous,
-      )
-    end
 
     def activerecord_raw_connection
       activerecord_connection.raw_connection

--- a/lib/sequel/extensions/activerecord_connection/postgres.rb
+++ b/lib/sequel/extensions/activerecord_connection/postgres.rb
@@ -14,6 +14,14 @@ module Sequel
       ensure
         result.clear if result
       end
+
+      def transaction(options = {})
+        %i[deferrable read_only synchronous].each do |key|
+          fail Error, "#{key.inspect} transaction option is currently not supported" if options.key?(key)
+        end
+
+        super
+      end
     end
   end
 end

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -21,6 +21,10 @@ describe "General adapter" do
     SQL
   end
 
+  it "returns transaction block value" do
+    assert_equal :result, @db.transaction { :result }
+  end
+
   it "reuses exiting transaction by default" do
     @db.transaction do
       assert_equal 1, ActiveRecord::Base.connection.open_transactions
@@ -139,10 +143,26 @@ describe "General adapter" do
     end
   end
 
-  it "doesn't support other transaction options" do
-    assert_raises Sequel::ActiveRecordConnection::Error do
+  it "raises exception on unsupported transaction options" do
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
       @db.transaction(isolation: :committed) { }
     end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(num_retries: 2) { }
+    end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(before_retry: -> {}) { }
+    end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(prepare: "foo") { }
+    end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(retry_on: KeyError) { }
+    end
+  end
+
+  it "ignores unknown transaction options" do
+    @db.transaction(foo: "bar") { }
   end
 
   it "doesn't support other transaction methods" do

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,38 +1,27 @@
 require "test_helper"
 
-describe "Don't breake Sequel::Model interface" do
+describe "Model integration" do
   before do
     connect_postgresql
 
-    @db.create_table! :test_models do
+    @db.create_table! :records do
       primary_key :id
       String :col
     end
 
-    Sequel::Model.db = @db
-    class TestModel < Sequel::Model
-      set_primary_key :id
-    end
-  end
-
-  after do
-    Object.send(:remove_const, :TestModel)
+    @model = Class.new(Sequel::Model)
+    @model.set_dataset(:records)
   end
 
   it ".create returns model" do
-    record = TestModel.create
-    assert_equal record.is_a?(TestModel), true
+    assert_instance_of @model, @model.create
   end
 
   it "#update returns model" do
-    record = TestModel.create
-    updated_record = record.update(col: "value")
-    assert_equal updated_record.is_a?(TestModel), true
+    assert_instance_of @model, @model.new.update(col: "value")
   end
 
   it "#save_changes executes successfully" do
-    record = TestModel.create
-    record.col = "value"
-    record.save_changes
+    @model.new(col: "value").save_changes
   end
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+describe "Don't breake Sequel::Model interface" do
+  before do
+    connect_postgresql
+
+    @db.create_table! :test_models do
+      primary_key :id
+      String :col
+    end
+
+    Sequel::Model.db = @db
+    class TestModel < Sequel::Model
+      set_primary_key :id
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestModel)
+  end
+
+  it ".create returns model" do
+    record = TestModel.create
+    assert_equal record.is_a?(TestModel), true
+  end
+
+  it "#update returns model" do
+    record = TestModel.create
+    updated_record = record.update(col: "value")
+    assert_equal updated_record.is_a?(TestModel), true
+  end
+
+  it "#save_changes executes successfully" do
+    record = TestModel.create
+    record.col = "value"
+    record.save_changes
+  end
+end

--- a/test/postgres_test.rb
+++ b/test/postgres_test.rb
@@ -126,4 +126,16 @@ describe "postgres connection" do
       INSERT INTO "records" ("time") VALUES ('2020-04-26 00:00:00.000000#{utc_offset}') RETURNING "id"
     SQL
   end
+
+  it "raises exception on unsupported transaction options" do
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(deferrable: true) { }
+    end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(read_only: true) { }
+    end
+    assert_raises(Sequel::ActiveRecordConnection::Error) do
+      @db.transaction(synchronous: true) { }
+    end
+  end unless RUBY_ENGINE == "jruby"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require "minitest/pride"
 
 require "active_record"
 require "sequel/core"
+require "sequel/model"
 
 require "stringio"
 require "active_support/core_ext/string"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,7 +67,6 @@ class Minitest::Test
       database: ":memory:",
     )
 
-
     @db = if RUBY_ENGINE == "jruby"
       Sequel.connect("jdbc:sqlite://", test: false)
     else
@@ -88,6 +87,7 @@ class Minitest::Test
   def teardown
     ActiveRecord::Base.remove_connection
     ActiveRecord::Base.default_timezone = :utc # reset default setting
+    Sequel::DATABASES.delete(@db)
   end
 
   def assert_logged(content)


### PR DESCRIPTION
Original `Sequel::Model#update` returns updated model, but the extension breaks it: `Sequel::Model#update` returns `nil`.

The PR should fix it.