### PR TITLE
Fully support Sequel's transaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+* Fully support Sequel transaction API (all transaction options, transaction/savepoint hooks etc.) (@janko)
+
 ## 0.2.6 (2020-07-19)
 
 * Return block result in `Sequel::Database#transaction` (@zabolotnov87, @janko)

--- a/lib/sequel/extensions/activerecord_connection/postgres.rb
+++ b/lib/sequel/extensions/activerecord_connection/postgres.rb
@@ -9,6 +9,8 @@ module Sequel
         else
           result.cmd_tuples
         end
+      rescue ActiveRecord::PreparedStatementCacheExpired
+        raise # ActiveRecord's transaction manager needs to handle this exception
       rescue ActiveRecord::StatementInvalid => exception
         raise_error(exception.cause, classes: database_error_classes)
       ensure

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -15,9 +15,9 @@ describe "General adapter" do
     @db.transaction { @db.run "SELECT 1" }
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -50,9 +50,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     @db.transaction do
@@ -64,9 +64,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     ActiveRecord::Base.transaction do
@@ -78,9 +78,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -94,11 +94,11 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SAVEPOINT active_record_1
       SELECT 1
       RELEASE SAVEPOINT active_record_1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     ActiveRecord::Base.transaction do
@@ -110,11 +110,11 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SAVEPOINT active_record_1
       SELECT 1
       RELEASE SAVEPOINT active_record_1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -128,11 +128,11 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SAVEPOINT active_record_1
       SELECT 1
       RELEASE SAVEPOINT active_record_1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -142,9 +142,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      ROLLBACK
     SQL
 
     assert_raises Sequel::Rollback do
@@ -155,9 +155,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      ROLLBACK
     SQL
   end
 
@@ -165,33 +165,33 @@ describe "General adapter" do
     @db.transaction(isolation: :uncommitted) { }
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     @db.transaction(isolation: :committed) { }
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SET TRANSACTION ISOLATION LEVEL READ COMMITTED
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     @db.transaction(isolation: :repeatable) { }
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
 
     @db.transaction(isolation: :serializable) { }
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -204,9 +204,9 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SELECT 1
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      ROLLBACK
     SQL
   end
 
@@ -216,8 +216,8 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
+      ROLLBACK
     SQL
 
     @db.transaction do
@@ -227,10 +227,10 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SAVEPOINT active_record_1
       ROLLBACK TO SAVEPOINT active_record_1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 
@@ -342,8 +342,8 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
+      ROLLBACK
     SQL
 
     @db.transaction do
@@ -353,10 +353,10 @@ describe "General adapter" do
     end
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       SAVEPOINT active_record_1
       ROLLBACK TO SAVEPOINT active_record_1
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
     SQL
   end
 

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -21,12 +21,55 @@ describe "General adapter" do
     SQL
   end
 
-  it "returns transaction block value" do
+  it "returns transaction block result" do
     assert_equal :result, @db.transaction { :result }
   end
 
-  it "reuses exiting transaction by default" do
+  it "knows when it's in a transaction" do
+    assert_equal false, @db.in_transaction?
+    assert_equal false, ActiveRecord::Base.connection.transaction_open?
+
     @db.transaction do
+      assert_equal true, @db.in_transaction?
+      assert_equal true, ActiveRecord::Base.connection.transaction_open?
+    end
+
+    ActiveRecord::Base.transaction do
+      assert_equal true, @db.in_transaction?
+      assert_equal true, ActiveRecord::Base.connection.transaction_open?
+    end
+  end
+
+  it "reuses existing transaction by default" do
+    @db.transaction do
+      assert_equal 1, ActiveRecord::Base.connection.open_transactions
+      @db.transaction do
+        assert_equal 1, ActiveRecord::Base.connection.open_transactions
+        @db.run "SELECT 1"
+      end
+    end
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SELECT 1
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    @db.transaction do
+      assert_equal 1, ActiveRecord::Base.connection.open_transactions
+      ActiveRecord::Base.transaction do
+        assert_equal 1, ActiveRecord::Base.connection.open_transactions
+        @db.run "SELECT 1"
+      end
+    end
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SELECT 1
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    ActiveRecord::Base.transaction do
       assert_equal 1, ActiveRecord::Base.connection.open_transactions
       @db.transaction do
         assert_equal 1, ActiveRecord::Base.connection.open_transactions
@@ -41,8 +84,8 @@ describe "General adapter" do
     SQL
   end
 
-  it "opens new transaction when savepoint: :only is passed" do
-    @db.transaction do
+  it "handles :savepoint option" do
+    ActiveRecord::Base.transaction do
       assert_equal 1, ActiveRecord::Base.connection.open_transactions
       @db.transaction(savepoint: :only) do
         assert_equal 2, ActiveRecord::Base.connection.open_transactions
@@ -57,10 +100,8 @@ describe "General adapter" do
       RELEASE SAVEPOINT active_record_1
       COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
     SQL
-  end
 
-  it "opens new transaction when savepoint: true is passed" do
-    @db.transaction do
+    ActiveRecord::Base.transaction do
       assert_equal 1, ActiveRecord::Base.connection.open_transactions
       @db.transaction(savepoint: true) do
         assert_equal 2, ActiveRecord::Base.connection.open_transactions
@@ -77,7 +118,7 @@ describe "General adapter" do
     SQL
   end
 
-  it "opens new transaction when auto_savepoint: true is passed" do
+  it "handles :auto_savepoint option" do
     @db.transaction(auto_savepoint: true) do
       assert_equal 1, ActiveRecord::Base.connection.open_transactions
       @db.transaction do
@@ -95,20 +136,7 @@ describe "General adapter" do
     SQL
   end
 
-  it "rolls back on Sequel::Rollback" do
-    @db.transaction do
-      @db.run "SELECT 1"
-      raise Sequel::Rollback
-    end
-
-    assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
-      SELECT 1
-      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
-    SQL
-  end
-
-  it "always rolls back when rollback: :always was passed" do
+  it "handles :rollback option" do
     @db.transaction(rollback: :always) do
       @db.run "SELECT 1"
     end
@@ -118,9 +146,7 @@ describe "General adapter" do
       SELECT 1
       ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
     SQL
-  end
 
-  it "re-raises rollback exception when rollback: :reraise was passed" do
     assert_raises Sequel::Rollback do
       @db.transaction(rollback: :reraise) do
         @db.run "SELECT 1"
@@ -135,52 +161,203 @@ describe "General adapter" do
     SQL
   end
 
-  it "knows when it's in a transaction" do
-    assert_equal false, @db.in_transaction?
+  it "handles :isolation option" do
+    @db.transaction(isolation: :uncommitted) { }
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    @db.transaction(isolation: :committed) { }
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    @db.transaction(isolation: :repeatable) { }
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    @db.transaction(isolation: :serializable) { }
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SET TRANSACTION ISOLATION LEVEL SERIALIZABLE
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+  end
+
+  it "rolls back on exceptions" do
+    assert_raises KeyError do
+      @db.transaction do
+        @db.run "SELECT 1"
+        raise KeyError
+      end
+    end
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SELECT 1
+      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+  end
+
+  it "rolls back on Sequel::Rollback" do
+    @db.transaction do
+      raise Sequel::Rollback
+    end
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
 
     @db.transaction do
-      assert_equal true, @db.in_transaction?
+      @db.transaction(savepoint: true) do
+        raise Sequel::Rollback
+      end
     end
+
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SAVEPOINT active_record_1
+      ROLLBACK TO SAVEPOINT active_record_1
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
   end
 
-  it "raises exception on unsupported transaction options" do
-    assert_raises(Sequel::ActiveRecordConnection::Error) do
-      @db.transaction(isolation: :committed) { }
+  it "supports #after_commit" do
+    after_commit_called = nil
+    @db.transaction do
+      @db.after_commit { after_commit_called = true }
     end
-    assert_raises(Sequel::ActiveRecordConnection::Error) do
-      @db.transaction(num_retries: 2) { }
+    assert after_commit_called
+
+    after_commit_called = nil
+    @db.transaction do
+      ActiveRecord::Base.transaction do
+        @db.after_commit { after_commit_called = true }
+      end
     end
-    assert_raises(Sequel::ActiveRecordConnection::Error) do
-      @db.transaction(before_retry: -> {}) { }
+    assert after_commit_called
+
+    after_commit_called = nil
+    @db.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        @db.after_commit { after_commit_called = true }
+      end
     end
-    assert_raises(Sequel::ActiveRecordConnection::Error) do
-      @db.transaction(prepare: "foo") { }
+    assert after_commit_called
+
+    after_commit_called = nil
+    @db.transaction do
+      @db.transaction do
+        @db.after_commit { after_commit_called = true }
+      end
     end
-    assert_raises(Sequel::ActiveRecordConnection::Error) do
-      @db.transaction(retry_on: KeyError) { }
+    assert after_commit_called
+
+    after_commit_called = nil
+    @db.transaction do
+      @db.transaction(savepoint: true) do
+        @db.after_commit { after_commit_called = true }
+      end
     end
+    assert after_commit_called
+
+    after_commit_called = nil
+    ActiveRecord::Base.transaction do
+      @db.transaction(savepoint: true) do
+        @db.after_commit { after_commit_called = true }
+      end
+    end
+    assert after_commit_called
   end
 
-  it "ignores unknown transaction options" do
-    @db.transaction(foo: "bar") { }
+  it "supports #after_rollback" do
+    after_rollback_called = nil
+    @db.transaction do
+      @db.after_rollback { after_rollback_called = true }
+      raise Sequel::Rollback
+    end
+    assert after_rollback_called
+
+    after_rollback_called = nil
+    @db.transaction do
+      ActiveRecord::Base.transaction do
+        @db.after_rollback { after_rollback_called = true }
+        raise Sequel::Rollback
+      end
+    end
+    assert after_rollback_called
+
+    after_rollback_called = nil
+    @db.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
+        @db.after_rollback { after_rollback_called = true }
+        raise Sequel::Rollback
+      end
+    end
+    assert after_rollback_called
+
+    after_rollback_called = nil
+    @db.transaction do
+      @db.transaction do
+        @db.after_rollback { after_rollback_called = true }
+        raise Sequel::Rollback
+      end
+    end
+    assert after_rollback_called
+
+    after_rollback_called = nil
+    @db.transaction do
+      @db.transaction(savepoint: true) do
+        @db.after_rollback { after_rollback_called = true }
+        raise Sequel::Rollback
+      end
+    end
+    assert after_rollback_called
+
+    after_rollback_called = nil
+    ActiveRecord::Base.transaction do
+      @db.transaction(savepoint: true) do
+        @db.after_rollback { after_rollback_called = true }
+        raise Sequel::Rollback
+      end
+    end
+    assert after_rollback_called
   end
 
-  it "doesn't support other transaction methods" do
-    assert_raises Sequel::ActiveRecordConnection::Error do
-      @db.after_commit {}
+  it "supports #rollback_on_exit" do
+    @db.transaction do
+      @db.rollback_on_exit
     end
 
-    assert_raises Sequel::ActiveRecordConnection::Error do
-      @db.after_rollback {}
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      ROLLBACK#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
+
+    @db.transaction do
+      @db.transaction(savepoint: true) do
+        @db.rollback_on_exit(savepoint: true)
+      end
     end
 
-    assert_raises Sequel::ActiveRecordConnection::Error do
-      @db.rollback_on_exit {}
-    end
-
-    assert_raises Sequel::ActiveRecordConnection::Error do
-      @db.rollback_checker {}
-    end
+    assert_logged <<-SQL.strip_heredoc
+      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      SAVEPOINT active_record_1
+      ROLLBACK TO SAVEPOINT active_record_1
+      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+    SQL
   end
 
   it "doesn't support Database#connect" do

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -31,9 +31,9 @@ describe "mysql2 connection" do
     assert_equal [:id, :col, :time], @db[:records].columns
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       INSERT INTO `records` (`col`) VALUES ('a'), ('b'), ('c')
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
       SELECT version()
       SELECT * FROM `records` ORDER BY `id`
     SQL

--- a/test/postgres_test.rb
+++ b/test/postgres_test.rb
@@ -29,9 +29,9 @@ describe "postgres connection" do
     assert_equal "c", records[2][:col]
 
     assert_logged <<-SQL.strip_heredoc
-      BEGIN#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      BEGIN
       INSERT INTO "records" ("col") VALUES ('a'), ('b'), ('c')
-      COMMIT#{' TRANSACTION' if RUBY_ENGINE == "jruby"}
+      COMMIT
       SELECT * FROM "records" ORDER BY "id"
     SQL
   end


### PR DESCRIPTION
Previously we had reimplemented a subset of the `Sequel::Database#transaction` implementation on top of `ActiveRecord::Base.transaction`, which meant you couldn't use some useful Sequel transaction features (such as `after_commit` hooks). That way you were effectively handicapped for using Sequel together with ActiveRecord, which didn't feel right. For example, `after_commit` hooks can be useful in Rodauth for some scenarios.

So we rewrite the transaction implementation to use ActiveRecord's lower-level transaction-related, letting Sequel handle its transaction options, transaction/savepoint hooks and other functionality relying on transaction state. We also translate transaction isolation levels and add extra code to account for transactions opened directly via ActiveRecord API. This makes Sequel's transaction API fully supported.

There is one known caveat though, which is that transaction hooks won't run if ActiveRecord holds the outer transaction (unless savepoints are used), because in this case the transaction gets committed directly by ActiveRecord. Hopefully that shouldn't be too much of an issue.
