### PR TITLE
Bump after_commit_everywhere

### DIFF
--- a/sequel-activerecord_connection.gemspec
+++ b/sequel-activerecord_connection.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sequel", "~> 5.16"
   spec.add_dependency "activerecord", ">= 4.2", "< 7"
-  spec.add_dependency "after_commit_everywhere", "~> 0.1.5"
+  spec.add_dependency "after_commit_everywhere", "~> 1.0.0"
 
   spec.add_development_dependency "sequel", "~> 5.38"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
[Release 1.0.0 has no actual changes](https://github.com/Envek/after_commit_everywhere/releases/tag/v1.0.0) so this shouldn't break. Not bumping this dependency is going to cause conflicts in the future with other gems that have `"~> 1.0.0"` in their gemspecs.