### PR TITLE
Add support for ActiveRecord 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add support for Active Record 8.0 (@phlipper)
+
 ## 1.5.0 (2024-10-16)
 
 * Avoid permanent connection checkout on Active Record 7.2+ (@janko)

--- a/gemfiles/Gemfile.activerecord-8.0
+++ b/gemfiles/Gemfile.activerecord-8.0
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec path: ".."
 
-gem "activerecord", "~> 8.0.0.beta1"
+gem "activerecord", "~> 8.0.0"
 
 platform :mri do
   gem "pg",      "~> 1.0"

--- a/sequel-activerecord_connection.gemspec
+++ b/sequel-activerecord_connection.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "sequel", "~> 5.38"
-  spec.add_dependency "activerecord", ">= 5.0", "< 8"
+  spec.add_dependency "activerecord", ">= 5.0", "< 8.1"
   spec.add_dependency "after_commit_everywhere", "~> 1.1"
 
   spec.add_development_dependency "sequel_pg" unless RUBY_ENGINE == "jruby"


### PR DESCRIPTION
# Overview

This PR adds support for ActiveRecord 8.0 which has been officially released.

## Notes

* Update `Gemfile.activerecord-8.0`
* Update `sequel-activerecord_connection.gemspec`
* Add a new CHANGELOG entry

This PR is required to support https://github.com/janko/rodauth-rails/pull/330

Thank you for all of your great work on these gems!