### PR TITLE
Bump actions/checkout from v3 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       ACTIVERECORD_VERSION: ${{ matrix.activerecord }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: "Install database packages"
         run: sudo apt-get -yqq install libpq-dev libmysqlclient-dev


### PR DESCRIPTION
actions/checkout@v3 uses Node.js 16, which reached EOL in September 2023.
v6 runs on Node.js 24 and improves credential security.