### PR TITLE
Upgrade CI database versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.5
+        image: postgres:18
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         env:
@@ -24,7 +24,7 @@ jobs:
           POSTGRES_PASSWORD: sequel_activerecord_connection
 
       mysql:
-        image: mysql:5.7
+        image: mysql:9.7
         ports: ["3306:3306"]
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
         env:


### PR DESCRIPTION
PostgreSQL 11 and MySQL 5.7 used in CI have both reached EOL.

- PostgreSQL 11.5 → 18 (11 EOL: November 2023)
- MySQL 5.7 → 9.7 LTS (5.7 EOL: October 2023)

Verified all CI jobs pass on a fork:
https://github.com/fkmy/sequel-activerecord_connection/actions/runs/25090788661